### PR TITLE
[CHK-1026] feat(consumers): add event consumer for transaction retry refund event

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/scheduler/queues/TransactionActivatedEventsConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/scheduler/queues/TransactionActivatedEventsConsumer.kt
@@ -23,6 +23,11 @@ import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 import java.util.*
 
+/**
+ * Event consumer for events related to transaction activation.
+ * This consumer's responsibilities are to handle expiration of transactions and subsequent refund
+ * for transaction stuck in a pending/transient state.
+ */
 @Service
 class TransactionActivatedEventsConsumer(
     @Autowired private val paymentGatewayClient: PaymentGatewayClient,

--- a/src/test/kotlin/it/pagopa/ecommerce/scheduler/queues/TransactionClosureErrorEventConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/scheduler/queues/TransactionClosureErrorEventConsumerTests.kt
@@ -3,11 +3,9 @@ package it.pagopa.ecommerce.scheduler.queues
 import com.azure.core.util.BinaryData
 import com.azure.spring.messaging.checkpoint.Checkpointer
 import it.pagopa.ecommerce.commons.TransactionTestUtils.*
-import it.pagopa.ecommerce.commons.documents.TransactionAuthorizedEvent
 import it.pagopa.ecommerce.commons.documents.TransactionClosureSendData
 import it.pagopa.ecommerce.commons.documents.TransactionClosureSentEvent
 import it.pagopa.ecommerce.commons.documents.TransactionEvent
-import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
 import it.pagopa.ecommerce.scheduler.exceptions.BadTransactionStatusException
 import it.pagopa.ecommerce.scheduler.repositories.TransactionsEventStoreRepository


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* make `TransactionActivatedEventsConsumer` handle refund retry events

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR allows `pagopa-ecommerce-scheduler-service` to handle refund retry events generated by the pending transactions batch (for this PR in particular we now handle `TransactionRefundRetriedEvent` as defined in pagopa/pagopa-ecommerce-commons#23).

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local unit tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Depends on #24 