### PR TITLE
[CHK-1026] feat(consumers): add event consumer for transaction retry closure event

### DIFF
--- a/src/test/kotlin/it/pagopa/ecommerce/scheduler/queues/TransactionClosureErrorEventConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/scheduler/queues/TransactionClosureErrorEventConsumerTests.kt
@@ -53,9 +53,8 @@ class TransactionClosureErrorEventConsumerTests {
         nodeService
     )
 
-
     @Test
-    fun `consumer processes bare message correctly with OK closure outcome`() = runTest {
+    fun `consumer processes bare closure error message correctly with OK closure outcome`() = runTest {
         val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
         val authorizationRequestEvent = transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
         val authorizationUpdateEvent = transactionAuthorizedEvent() as TransactionEvent<Any>
@@ -109,7 +108,7 @@ class TransactionClosureErrorEventConsumerTests {
     }
 
     @Test
-    fun `consumer processes bare message correctly with KO closure outcome`() = runTest {
+    fun `consumer processes bare closure error message correctly with KO closure outcome`() = runTest {
         val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
         val authorizationRequestEvent = transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
         val authorizationUpdateEvent = transactionAuthorizationFailedEvent() as TransactionEvent<Any>
@@ -157,6 +156,62 @@ class TransactionClosureErrorEventConsumerTests {
             /* Asserts */
             verify(checkpointer, Mockito.times(1)).success()
             verify(nodeService, Mockito.times(1)).closePayment(UUID.fromString(TRANSACTION_ID), ClosePaymentRequestV2Dto.OutcomeEnum.KO)
+            verify(transactionClosureSentEventRepository, Mockito.times(1)).save(any()) // FIXME: Unable to use better argument captor because of misbehaviour in static mocking
+            verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
+        }
+    }
+
+    @Test
+    fun `consumer processes closure retry message correctly`() = runTest {
+        val closureRetriedEvent = transactionClosureRetriedEvent(0)
+
+        val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+        val authorizationRequestEvent = transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+        val authorizationUpdateEvent = transactionAuthorizedEvent() as TransactionEvent<Any>
+        val closureErrorEvent = transactionClosureErrorEvent() as TransactionEvent<Any>
+
+        val events = listOf(activationEvent, authorizationRequestEvent, authorizationUpdateEvent, closureErrorEvent)
+
+        val expectedUpdatedTransaction = transactionDocument(TransactionStatusDto.CLOSED, ZonedDateTime.parse(activationEvent.creationDate))
+
+        val transactionDocument = transactionDocument(TransactionStatusDto.CLOSURE_ERROR, ZonedDateTime.parse(activationEvent.creationDate))
+
+        val uuidFromStringWorkaround = "00000000-0000-0000-0000-000000000000" // FIXME: Workaround for static mocking apparently not working
+        val expectedClosureEvent = TransactionClosureSentEvent(
+            uuidFromStringWorkaround,
+            TransactionClosureSendData(
+                ClosePaymentResponseDto.OutcomeEnum.OK,
+                TransactionStatusDto.CLOSED
+            )
+        )
+
+        /* preconditions */
+        given(checkpointer.success()).willReturn(Mono.empty())
+        given(transactionsEventStoreRepository.findByTransactionId(any()))
+            .willReturn(events.toFlux())
+        given(transactionsViewRepository.findByTransactionId(any())).willReturn(Mono.just(transactionDocument))
+        given(transactionsViewRepository.save(any())).willAnswer { Mono.just(it.arguments[0]) }
+        given(transactionClosureSentEventRepository.save(any())).willReturn(Mono.just(expectedClosureEvent))
+        given(nodeService.closePayment(UUID.fromString(uuidFromStringWorkaround), ClosePaymentRequestV2Dto.OutcomeEnum.OK)).willReturn(ClosePaymentResponseDto().apply {
+            outcome = ClosePaymentResponseDto.OutcomeEnum.OK
+        })
+
+        /* test */
+
+        val closureEventId = UUID.fromString(expectedClosureEvent.id)
+
+        Mockito.mockStatic(UUID::class.java).use { uuid ->
+            uuid.`when`<Any>(UUID::randomUUID).thenReturn(closureEventId)
+            uuid.`when`<Any> { UUID.fromString(any()) }.thenCallRealMethod()
+
+            transactionClosureErrorEventsConsumer.messageReceiver(
+                BinaryData.fromObject(closureRetriedEvent).toBytes(),
+                checkpointer
+            ).block()
+
+            /* Asserts */
+            verify(checkpointer, Mockito.times(1)).success()
+            verify(nodeService, Mockito.times(1)).closePayment(UUID.fromString(TRANSACTION_ID), ClosePaymentRequestV2Dto.OutcomeEnum.OK)
             verify(transactionClosureSentEventRepository, Mockito.times(1)).save(any()) // FIXME: Unable to use better argument captor because of misbehaviour in static mocking
             verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
         }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* add event consumer for transaction retry closure event

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR allows pagopa-ecommerce-scheduler-service to handle refund retry events generated by the pending transactions batch (for this PR in particular we now handle TransactionRefundRetriedEvent as defined in https://github.com/pagopa/pagopa-ecommerce-commons/pull/23).

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local unit tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Depends on #24 